### PR TITLE
Replace .sierra.json reference with .contract_class.json

### DIFF
--- a/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
+++ b/components/Starknet/modules/quick-start/pages/declare-a-smart-contract.adoc
@@ -92,7 +92,7 @@ A contract can be declared on Starknet using Starkli by running following comman
 
 [source,bash]
 ----
-starkli declare target/dev/<CONTRACT_NAME>.sierra.json --network=sepolia
+starkli declare target/dev/<CONTRACT_NAME>.contract_class.json --network=sepolia
 ----
 
 When using `starkli declare`, Starkli will do its best to identify the compiler version of the declared class. In case it fails, the `--compiler-version` flag can be used to specify the version of the compiler as follows:
@@ -135,7 +135,7 @@ The following is an example of declaring a contract with both a a custom RPC end
 
 [source,bash]
 ----
-starkli declare target/dev/<CONTRACT_NAME>.sierra.json \
+starkli declare target/dev/<CONTRACT_NAME>.contract_class.json \
     --rpc=https://starknet-sepolia.infura.io/v3/<API_KEY> \
     --compiler-version=2.6.0 \
 ----


### PR DESCRIPTION
Replace old references to <CONTRACT_NAME>.sierra.json with the newer <CONTRACT_NAME>.contract_class.json. This aligns the documentation with the current compiler output and helps first-time users avoid confusion when locating contract artifacts


